### PR TITLE
Don't continually retry event processing

### DIFF
--- a/src/Onwrd.EntityFrameworkCore.Tests/EndToEndTests.cs
+++ b/src/Onwrd.EntityFrameworkCore.Tests/EndToEndTests.cs
@@ -105,10 +105,8 @@ namespace Onwrd.EntityFrameworkCore.Tests
                     onwrdConfig.UseOnwardProcessor<TestOnwardProcessor>();
                     onwrdConfig.ConfigureRetryOptions(retryConfig =>
                     {
-                        retryConfig.PollPeriod = TimeSpan.FromSeconds(1);
-                        retryConfig.Attempts = 3;
+                        retryConfig.MaximumRetryAttempts = 3;
                         retryConfig.RetryAfter = TimeSpan.FromSeconds(0);
-                        retryConfig.StopWhenNothingProcessed = true;
                     });
                 });
 

--- a/src/Onwrd.EntityFrameworkCore/IOnwardRetryManager.cs
+++ b/src/Onwrd.EntityFrameworkCore/IOnwardRetryManager.cs
@@ -5,6 +5,13 @@ namespace Onwrd.EntityFrameworkCore
     public interface IOnwardRetryManager<TContext>
         where TContext : DbContext
     {
-        Task RetryOnwardProcessing(CancellationToken cancellationToken);
+        /// <summary>
+        /// Retries unprocessed events in the order that they occurred.
+        /// A RetryResult indicates whether the Retry operation was a success, and can either be a SuccessfulRetryResult or 
+        /// an UnsuccessfulRetryResult. Attempting casts to either can give further details
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns>RetryResult</returns>
+        Task<RetryResult> RetryOnwardProcessing(CancellationToken cancellationToken);
     }
 }

--- a/src/Onwrd.EntityFrameworkCore/Internal/RetryUnitOfWorkResult.cs
+++ b/src/Onwrd.EntityFrameworkCore/Internal/RetryUnitOfWorkResult.cs
@@ -1,9 +1,0 @@
-﻿namespace Onwrd.EntityFrameworkCore.Internal
-{
-    internal enum RetryUnitOfWorkResult
-    {
-        Processed,
-        NoEvents,
-        RetriesExceeded
-    }
-}

--- a/src/Onwrd.EntityFrameworkCore/OnwrdRetryConfiguration.cs
+++ b/src/Onwrd.EntityFrameworkCore/OnwrdRetryConfiguration.cs
@@ -2,13 +2,9 @@
 {
     public class OnwrdRetryConfiguration
     {
-        public int Attempts { get; set; } = 5;
+        public int MaximumRetryAttempts { get; set; } = 5;
 
         public TimeSpan RetryAfter = TimeSpan.FromSeconds(5);
-
-        public TimeSpan PollPeriod { get; set; } = TimeSpan.FromSeconds(5);
-
-        internal bool StopWhenNothingProcessed { get; set; } = false;
 
         internal OnwrdRetryConfiguration()
         {

--- a/src/Onwrd.EntityFrameworkCore/RetryResult.cs
+++ b/src/Onwrd.EntityFrameworkCore/RetryResult.cs
@@ -1,0 +1,36 @@
+﻿namespace Onwrd.EntityFrameworkCore
+{
+    public abstract class RetryResult
+    {
+        public bool IsSuccess { get; protected set; }
+
+        protected RetryResult()
+        {
+        }
+    }
+
+    public class SuccessfulRetryResult : RetryResult
+    {
+        public int NumberOfEventsProcessed { get; }
+
+        internal SuccessfulRetryResult(int numberOfEventsProcessed)
+        {
+            this.IsSuccess = true;
+            this.NumberOfEventsProcessed = numberOfEventsProcessed;
+        }
+    }
+
+    public class UnsuccessfulRetryResult : RetryResult
+    {
+        public int NumberOfRetries { get; }
+
+        public Exception LastException { get; }
+
+        internal UnsuccessfulRetryResult(int numberOfRetries, Exception lastException)
+        {
+            this.NumberOfRetries = numberOfRetries;
+            this.LastException = lastException;
+            this.IsSuccess = false;
+        }
+    }
+}


### PR DESCRIPTION
- Quit retry processing when there are no events to process, or the MaximumRetryAttempts have been exceeded for an event.
- Refactor configuration to reflect the above changes